### PR TITLE
Values in text match defaults

### DIFF
--- a/docs/book/content/calibration/firms.md
+++ b/docs/book/content/calibration/firms.md
@@ -11,4 +11,4 @@ The [OG-Core firm theory documentation](https://pslmodels.github.io/OG-Core/cont
 
 ### Capital's share of output
 
-Here, we use a default value of $\gamma =0.41$, which comes from national accounts data.
+Here, we use a default value of $\gamma =0.588$, which comes from national accounts data.

--- a/docs/book/content/calibration/macro.md
+++ b/docs/book/content/calibration/macro.md
@@ -3,17 +3,17 @@
 
 ## Economic Assumptions
 
-As the default rate of labor augmenting technological change, $g_y$, we use a value of 3.8%.  The average annual growth rate in GDP per capita in the Philippines between 2000 and 2019 is 3.8% per year.
+As the default rate of labor augmenting technological change, $g_y$, we use a value of 3.6%.  The average annual growth rate in GDP per capita in the Philippines between 2000 and 2019 is 3.6% per year.
 
 ## Open Economy Parameters
 
 ### Foreign holding of government debt in the initial period
 
-The path of foreign holding of domestic debt is endogenous, but the initial period stock of debt held by foreign investors is exogenous.  We set this parameter, `initial_foreign_debt_ratio` to 0.76, as determined from data from the World Bank's World Development Indicators.
+The path of foreign holding of domestic debt is endogenous, but the initial period stock of debt held by foreign investors is exogenous.  We set this parameter, `initial_foreign_debt_ratio` to 0.142, as determined from data from the World Bank's World Development Indicators.
 
 ### Foreign purchases of newly issued debt
 
-We set $\zeta_D = 0.9$.  This is the average share of foreign purchases of newly issued government debt found from the World Bank WDI.
+We set $\zeta_D = 0.142$.  This was not directly observed in the data, so the value was set to the current share of foreign holdings of government debt.
 
 ### Foreign holdings of excess capital
 
@@ -23,14 +23,14 @@ We set $\zeta_K = 0.9$. Note, this parameter is harder to pin down from the data
 
 ### Government Debt
 
-The path of government debt is endogenous.  But the initial value is exogenous.  To avoid converting between model units and dollars, we calibrate the initial debt to GDP ratio, rather than the dollar value of the debt.  This is the model parameter $\alpha_D$.  We compute this from the ratio of publicly held debt outstanding to GDP.  Based on 2023 values, this gives us a ratio of 0.398.
+The path of government debt is endogenous.  But the initial value is exogenous.  To avoid converting between model units and dollars, we calibrate the initial debt to GDP ratio, rather than the dollar value of the debt.  This is the model parameter $\alpha_D$.  We compute this from the ratio of publicly held debt outstanding to GDP.  Based on [a 2024Q1 report from Treasury](https://www.treasury.gov.ph/?p=64737) the value is 0.60.
 
 ### Aggregate transfers
 
-Aggregate (non-Social Security) transfers to households are set as a share of GDP with the parameter $\alpha_T$. We exclude Social Security from transfers since it is modeled specifically. With this definition, the share of transfers to GDP in 2015 is 1.3% according to [IMF data](https://data.imf.org/?sk=b052f0f0-c166-43b6-84fa-47cccae3e219&hide_uv=1).
+Aggregate (non-Social Security) transfers to households are set as a share of GDP with the parameter $\alpha_T$. We exclude Social Security from transfers since it is modeled specifically. With this definition, the share of transfers to GDP in 2023 is found to be 9.7% using [IMF data](https://www.imf.org/external/datamapper/profile/PHL).  The value found by differencing out government consumption expenditures (described below) from total government spending as report in the IMF data.
 
 ### Government expenditures
 
 Government spending on goods and services are also set as a share of GDP with the parameter $\alpha_G$. We define government spending as:
     <center>Government Spending = Total Outlays - Transfers - Net Interest on Debt - Social Security</center>
-With this definition, the share of government expenditure to GDP is 13.2% based on [data from the IMF](https://data.imf.org/?sk=b052f0f0-c166-43b6-84fa-47cccae3e219&hide_uv=1).
+With this definition, the share of government expenditure to GDP is 14.2% based on the World Bank World Development Indicators.

--- a/ogphl/input_output.py
+++ b/ogphl/input_output.py
@@ -40,11 +40,9 @@ def get_alpha_c(sam=SAM, cons_dict=CONS_DICT):
         "hhd-u4",
         "hhd-u5",
     ]
-    print("COLS = ", SAM[hh_cols].columns)
     alpha_c = {}
     overall_sum = 0
     for key, value in cons_dict.items():
-        print("value = ", value)
         # note the subtraction of the row to focus on domestic consumption
         category_total = (
             sam.loc[sam.index.isin(value), hh_cols].values.astype(float).sum()


### PR DESCRIPTION
This PR updates the documentation to ensure that the values described in the text match those in `ogphl_default_parameters.json`.