### PR TITLE
Fixed typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ docs/book/_build/*
 */OG-PHL_example_plots/*
 *ogphl_example_output.csv
 */OG-PHL-Example/*
-*run_api_token.txt
+*un_api_token.txt


### PR DESCRIPTION
This PR fixes a typo in `.gitignore`. @jdebacker 