### PR TITLE
Make default start year 2025

### DIFF
--- a/ogphl/ogphl_default_parameters.json
+++ b/ogphl/ogphl_default_parameters.json
@@ -2413,7 +2413,7 @@
     ],
     "budget_balance": false,
     "baseline_spending": false,
-    "start_year": 2023,
+    "start_year": 2025,
     "tax_func_type": "linear",
     "labor_income_tax_noncompliance_rate": [
         [


### PR DESCRIPTION
This PR updates the `ogphl_default_parameters.json` to use 2025 as the model start year.