### PR TITLE
Update publish_to_pypi.yml

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -21,6 +21,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install wheel
+          pip install setuptools
           python setup.py sdist bdist_wheel
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2025-02-11 16:30:00
+
+### Added
+
+- Added `import setuptools` to `publish_to_pypi.yml`
+
 ## [0.0.8] - 2025-02-11 14:00:00
 
 ### Added
@@ -54,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This version is a pre-release alpha. The example run script OG-PHL/examples/run_og_phl.py runs, but the model is not currently calibrated to represent the Philippines economy and population.
 
+[0.0.9]: https://github.com/EAPD-DRB/OG-PHL/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/EAPD-DRB/OG-PHL/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/EAPD-DRB/OG-PHL/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/EAPD-DRB/OG-PHL/compare/v0.0.4...v0.0.6

--- a/ogphl/__init__.py
+++ b/ogphl/__init__.py
@@ -8,4 +8,4 @@ from ogphl.input_output import *
 from ogphl.macro_params import *
 from ogphl.utils import *
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogphl",
-    version="0.0.8",
+    version="0.0.9",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="Philippines Calibration for OG-Core",


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR adds `import setuptools` to `publish_to_pypi.yml`. This GH Action was breaking without the import.
