### PR TITLE
Updates to environment and example script imports

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - dask>=2.30.0
 - dask-core>=2.30.0
 - distributed>=2.30.1
+- marshmallow<4.0.0
 - paramtools>=0.15.0
 - sphinx>=3.5.4
 - sphinx-book-theme>=0.1.3

--- a/examples/run_og_phl.py
+++ b/examples/run_og_phl.py
@@ -8,7 +8,6 @@ import time
 import copy
 import importlib.resources
 import matplotlib.pyplot as plt
-import ogcore
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
@@ -18,7 +17,7 @@ from ogphl.calibrate import Calibration
 from ogphl.utils import is_connected
 
 # Use a custom matplotlib style file for plots
-# plt.style.use("ogcore.OGcorePlots")
+plt.style.use("ogcore.OGcorePlots")
 
 
 def main():

--- a/examples/run_og_phl_multi_industry.py
+++ b/examples/run_og_phl_multi_industry.py
@@ -9,17 +9,14 @@ import copy
 import numpy as np
 import importlib.resources
 import matplotlib.pyplot as plt
-import ogcore
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
 from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
-from ogphl.calibrate import Calibration
-from ogphl.utils import is_connected
 
 # Use a custom matplotlib style file for plots
-# plt.style.use("ogcore.OGcorePlots")
+plt.style.use("ogcore.OGcorePlots")
 
 
 def main():


### PR DESCRIPTION
This PR does two things:
1. It adds a pin for `marshmallow<4.0.0` to `enviornment.yml`.  This is a temporary fix to a breaking change in `paramtools` caused by the update to `marshmallow 4.0.0` (see ParamTools [Issue #144](https://github.com/PSLmodels/ParamTools/issues/144))
2. Unused imports are removed from the example scripts