### PR TITLE
Port calibration API structure and offline gating

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build # Build Jupyter Book
         shell: bash -l {0}
         run: |
-          pip install jupyter-book>=0.11.3
-          pip install sphinxcontrib-bibtex>=2.0.0
+          pip install "jupyter-book<2.0.0"
+          pip install "sphinxcontrib-bibtex>=2.0.0"
           pip install -e .
           python -m ipykernel install --user --name=ogphl-dev
           jb build ./docs/book

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build # Build Jupyter Book
         shell: bash -l {0}
         run: |
-          pip install jupyter-book>=0.11.3
-          pip install sphinxcontrib-bibtex>=2.0.0
+          pip install "jupyter-book<2.0.0"
+          pip install "sphinxcontrib-bibtex>=2.0.0"
           pip install -e .
           python -m ipykernel install --user --name=ogphl-dev
           jb build ./docs/book

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ Once the package is installed, one can adjust parameters in the OG-Core `Specifi
 ```
 from ogcore.parameters import Specifications
 from ogphl.calibrate import Calibration
+from ogphl.utils import is_connected
 p = Specifications()
-c = Calibration(p)
-updated_params = c.get_dict()
-p.update_specifications({'initial_debt_ratio': updated_params['initial_debt_ratio']})
+if is_connected():
+    c = Calibration(p, update_from_api=True)
+    updated_params = c.get_dict()
+    p.update_specifications(updated_params)
 ```
 
 ## Disclaimer

--- a/docs/book/content/UNtutorial/solutions/3perOG/SS.py
+++ b/docs/book/content/UNtutorial/solutions/3perOG/SS.py
@@ -28,7 +28,6 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
 import os
 
-
 # Define functions
 
 

--- a/docs/create_doc_figures.py
+++ b/docs/create_doc_figures.py
@@ -14,7 +14,6 @@ from ogcore import parameter_plots as pp
 from ogcore import demographics as demog
 import ogphl
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 UN_COUNTRY_CODE = "608"
 plot_path = os.path.join(CUR_DIR, "book", "content", "calibration", "images")

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,6 @@ dependencies:
 - pip
 - pip:
   - openpyxl>=3.1.2
-  - pandas-datareader
   - linecheck
   - ogcore>=0.14.5
   - sphinx-exercise

--- a/examples/run_og_phl.py
+++ b/examples/run_og_phl.py
@@ -54,7 +54,7 @@ def main():
     p.update_specifications(defaults)
     # Update parameters from calibrate.py Calibration class
     if is_connected():  # only update if connected to internet
-        c = Calibration(p)
+        c = Calibration(p, update_from_api=True)
         updated_params = c.get_dict()
         p.update_specifications(updated_params)
 

--- a/ogphl/calibrate.py
+++ b/ogphl/calibrate.py
@@ -1,9 +1,9 @@
 from ogphl import macro_params, income
 from ogphl import input_output as io
 import os
+import warnings
 import numpy as np
 import datetime
-from ogcore import demographics
 
 UN_COUNTRY_CODE = "608"
 
@@ -18,14 +18,19 @@ class Calibration:
         macro_data_end_year=datetime.datetime(2023, 1, 1),
         demographic_data_path=None,
         output_path=None,
+        update_from_api=False,
     ):
         """
         Constructor for the Calibration class.
 
         Args:
             p (OG-Core Specifications object): model parameters
+            macro_data_start_year (datetime): start date for macro data
+            macro_data_end_year (datetime): end date for macro data
             demographic_data_path (str): path to save demographic data
             output_path (str): path to save output to
+            update_from_api (bool): Set True to pull updated data from
+                online sources
 
         Returns:
             None
@@ -36,70 +41,100 @@ class Calibration:
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
 
+        # Initialize with overlay values only. Existing values on p are the
+        # baseline from the packaged defaults.
+        self.macro_params = {}
+        self.demographic_params = {}
+        self.e = None
+        self.alpha_c = np.array([1.0]) if p.I == 1 else None
+        self.io_matrix = np.array([[1.0]]) if p.M == 1 else None
+
+        if not update_from_api:
+            return
+
         # Macro estimation
-        self.macro_params = macro_params.get_macro_params(
-            macro_data_start_year, macro_data_end_year
-        )
+        try:
+            self.macro_params = macro_params.get_macro_params(
+                macro_data_start_year,
+                macro_data_end_year,
+                update_from_api=update_from_api,
+            )
+        except Exception as exc:
+            warnings.warn(f"Macro params update failed: {exc}", stacklevel=2)
 
         # io matrix and alpha_c
-        if p.I > 1:  # no need if just one consumption good
-            alpha_c_dict = io.get_alpha_c()
-            # check that model dimensions are consistent with alpha_c
-            assert p.I == len(list(alpha_c_dict.keys()))
-            self.alpha_c = np.array(list(alpha_c_dict.values()))
-        else:
-            self.alpha_c = np.array([1.0])
-        if p.M > 1:  # no need if just one production good
-            io_df = io.get_io_matrix()
-            # check that model dimensions are consistent with io_matrix
-            assert p.M == len(list(io_df.keys()))
-            self.io_matrix = io_df.values
-        else:
-            self.io_matrix = np.array([[1.0]])
+        if p.I > 1:
+            try:
+                alpha_c_dict = io.get_alpha_c()
+                # check that model dimensions are consistent with alpha_c
+                assert p.I == len(list(alpha_c_dict.keys()))
+                self.alpha_c = np.array(list(alpha_c_dict.values()))
+            except Exception as exc:
+                warnings.warn(f"alpha_c update failed: {exc}", stacklevel=2)
+        if p.M > 1:
+            try:
+                io_df = io.get_io_matrix()
+                # check that model dimensions are consistent with io_matrix
+                assert p.M == len(list(io_df.keys()))
+                self.io_matrix = io_df.values
+            except Exception as exc:
+                warnings.warn(f"io_matrix update failed: {exc}", stacklevel=2)
 
-        # demographics
-        self.demographic_params = demographics.get_pop_objs(
-            p.E,
-            p.S,
-            p.T,
-            0,
-            99,
-            country_id=UN_COUNTRY_CODE,
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-            download_path=demographic_data_path,
-        )
+        # Demographics and income are atomic because e depends on demography.
+        try:
+            from ogcore import demographics
 
-        # demographics for 80 period lives (needed for getting e below)
-        demog80 = demographics.get_pop_objs(
-            20,
-            80,
-            p.T,
-            0,
-            99,
-            country_id=UN_COUNTRY_CODE,
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-        )
+            self.demographic_params = demographics.get_pop_objs(
+                p.E,
+                p.S,
+                p.T,
+                0,
+                99,
+                country_id=UN_COUNTRY_CODE,
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+                download_path=demographic_data_path,
+            )
 
-        # earnings profiles
-        self.e = income.get_e_interp(
-            p.E,
-            p.S,
-            p.J,
-            p.lambdas,
-            demog80["omega_SS"],
-        )
+            # demographics for 80 period lives (needed for getting e below)
+            demog80 = demographics.get_pop_objs(
+                20,
+                80,
+                p.T,
+                0,
+                99,
+                country_id=UN_COUNTRY_CODE,
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+            )
+
+            # earnings profiles
+            self.e = income.get_e_interp(
+                p.E,
+                p.S,
+                p.J,
+                p.lambdas,
+                demog80["omega_SS"],
+            )
+        except Exception as exc:
+            warnings.warn(
+                f"Demographics/income update failed: {exc}", stacklevel=2
+            )
+            self.demographic_params = {}
+            self.e = None
 
     # method to return all newly calibrated parameters in a dictionary
     def get_dict(self):
-        dict = {}
-        dict.update(self.macro_params)
-        dict["e"] = self.e
-        dict["alpha_c"] = self.alpha_c
-        dict["io_matrix"] = self.io_matrix
-        dict.update(self.demographic_params)
+        d = {}
+        d.update(self.macro_params)
+        d.update(self.demographic_params)
+        if self.e is not None:
+            d["e"] = self.e
+        if self.alpha_c is not None:
+            d["alpha_c"] = self.alpha_c
+        if self.io_matrix is not None:
+            d["io_matrix"] = self.io_matrix
 
-        return dict
+        return d

--- a/ogphl/input_output.py
+++ b/ogphl/input_output.py
@@ -3,7 +3,6 @@ import numpy as np
 import os
 from ogphl.constants import CONS_DICT, PROD_DICT
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 """
 Read in Social Accounting Matrix (SAM) file

--- a/ogphl/input_output.py
+++ b/ogphl/input_output.py
@@ -8,15 +8,26 @@ CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 """
 Read in Social Accounting Matrix (SAM) file
 """
-# Read in SAM file
-# SAM file:
 sam_path = os.path.join(CUR_DIR, "data", "002_IFPRI_SAM_PHL_2018_SAM.csv")
-SAM = pd.read_csv(sam_path, index_col=1, thousands=",")
-# replace NaN with 0
-SAM.fillna(0, inplace=True)
 
 
-def get_alpha_c(sam=SAM, cons_dict=CONS_DICT):
+def read_SAM():
+    """
+    Read in the packaged Social Accounting Matrix (SAM) file.
+
+    Returns:
+        SAM (pd.DataFrame | None): Social Accounting Matrix, or None if unavailable
+    """
+    try:
+        sam = pd.read_csv(sam_path, index_col=1, thousands=",")
+        sam.fillna(0, inplace=True)
+        return sam
+    except Exception as exc:
+        print(f"Failed to read packaged SAM file: {exc}")
+        return None
+
+
+def get_alpha_c(sam=None, cons_dict=CONS_DICT):
     """
     Calibrate the alpha_c vector, showing the shares of household
     expenditures for each consumption category
@@ -28,6 +39,10 @@ def get_alpha_c(sam=SAM, cons_dict=CONS_DICT):
     Returns:
         alpha_c (dict): Dictionary of shares of household expenditures
     """
+    if sam is None:
+        sam = read_SAM()
+    if sam is None:
+        raise RuntimeError("SAM data is unavailable. Cannot compute alpha_c.")
     hh_cols = [
         "hhd-r1",
         "hhd-r2",
@@ -55,7 +70,7 @@ def get_alpha_c(sam=SAM, cons_dict=CONS_DICT):
     return alpha_c
 
 
-def get_io_matrix(sam=SAM, cons_dict=CONS_DICT, prod_dict=PROD_DICT):
+def get_io_matrix(sam=None, cons_dict=CONS_DICT, prod_dict=PROD_DICT):
     """
     Calibrate the io_matrix array.  This array relates the share of each
     production category in each consumption category
@@ -68,6 +83,12 @@ def get_io_matrix(sam=SAM, cons_dict=CONS_DICT, prod_dict=PROD_DICT):
     Returns:
         io_df (pd.DataFrame): Dataframe of io_matrix
     """
+    if sam is None:
+        sam = read_SAM()
+    if sam is None:
+        raise RuntimeError(
+            "SAM data is unavailable. Cannot compute io_matrix."
+        )
     # Create initial matrix as dataframe of 0's to fill in
     io_dict = {}
     for key in prod_dict.keys():

--- a/ogphl/macro_params.py
+++ b/ogphl/macro_params.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 import requests
 
-
 GDP_GROWTH_START_YEAR = 2000
 GDP_GROWTH_END_YEAR = 2019
 EXTERNAL_DEBT_REPORTING_LAG_YEARS = 2

--- a/ogphl/macro_params.py
+++ b/ogphl/macro_params.py
@@ -1,43 +1,310 @@
 """
-This module uses data from World Bank WDI, World Bank Quarterly Public
-Sector Debt (QPSD) database, the IMF, and UN ILO to find values for
-parameters for the OG-PHL model that rely on macro data for calibration.
+This module uses data from World Bank WDI, the IMF, and UN ILO to find
+values for parameters for the OG-PHL model that rely on macro data for
+calibration.
 """
 
 # imports
-from pandas_datareader import wb
-import pandas as pd
-import numpy as np
-import requests
 import datetime
-import statsmodels.api as sm
 from io import StringIO
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import requests
+
+
+GDP_GROWTH_START_YEAR = 2000
+GDP_GROWTH_END_YEAR = 2019
+EXTERNAL_DEBT_REPORTING_LAG_YEARS = 2
+ILOSTAT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/91.0.4472.124 Safari/537.36"
+    )
+}
+
+
+def _fetch_wb_data(indicators, country_iso, start_year, end_year, source):
+    """
+    Fetch a set of World Bank indicators and return a single DataFrame.
+
+    Args:
+        indicators (dict): mapping of human-readable labels to indicator codes
+        country_iso (str): ISO country code
+        start_year (int): first year to request
+        end_year (int): last year to request
+        source (int): World Bank source ID
+
+    Returns:
+        pandas.DataFrame: DataFrame indexed by year/quarter label
+    """
+    if source == 2:
+        date_range = f"{start_year}:{end_year}"
+    elif source == 20:
+        date_range = f"{start_year}Q1:{end_year}Q4"
+    else:
+        raise ValueError(f"Unsupported World Bank source: {source}")
+
+    data_frames = []
+    for label, indicator_code in indicators.items():
+        response = requests.get(
+            (
+                "https://api.worldbank.org/v2/country/"
+                f"{country_iso}/indicator/{indicator_code}"
+            ),
+            params={
+                "date": date_range,
+                "source": source,
+                "format": "json",
+                "per_page": 10000,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ValueError(
+                f"Malformed World Bank response for {indicator_code}"
+            ) from exc
+
+        if (
+            not isinstance(payload, list)
+            or len(payload) < 2
+            or not isinstance(payload[1], list)
+            or not payload[1]
+        ):
+            raise ValueError(
+                f"Empty or malformed World Bank response for {indicator_code}"
+            )
+
+        series_data = {}
+        for row in payload[1]:
+            date = row.get("date")
+            if date is None:
+                continue
+            series_data[date] = row.get("value")
+
+        if not series_data:
+            raise ValueError(
+                f"No dated observations in World Bank response for {indicator_code}"
+            )
+
+        series = pd.Series(series_data, name=label)
+        series = pd.to_numeric(series, errors="coerce")
+        data_frames.append(series.to_frame())
+
+    data = pd.concat(data_frames, axis=1)
+    data.index.name = "year"
+    return data.sort_index(ascending=False)
+
+
+def _annual_index(data):
+    """
+    Convert a World Bank annual response index to integer years.
+    """
+    annual_data = data.copy()
+    annual_data.index = pd.to_numeric(annual_data.index, errors="coerce")
+    annual_data = annual_data.loc[annual_data.index.notna()]
+    annual_data.index = annual_data.index.astype(int)
+    return annual_data.sort_index()
+
+
+def _latest_at_or_before(series, target_year, source_name):
+    """
+    Return the value for target_year or the latest nonmissing prior year.
+    """
+    valid = series.dropna()
+    valid = valid.loc[valid.index <= int(target_year)]
+    if valid.empty:
+        raise ValueError(
+            f"No complete {source_name} data available up to {target_year}"
+        )
+
+    selected_year = (
+        int(target_year)
+        if int(target_year) in valid.index
+        else int(valid.index.max())
+    )
+    if selected_year != int(target_year):
+        print(
+            f"Warning: No {source_name} data for {target_year}. "
+            f"Using last available year: {selected_year}"
+        )
+    return valid.loc[selected_year]
+
+
+def _get_imf_macro_params(country_iso, target_year, data_path=None):
+    """
+    Fetch IMF GFS data and compute alpha_T and alpha_G.
+
+    Args:
+        country_iso (str): ISO alpha-3 country code
+        target_year (int): preferred calibration year
+        data_path (str | Path | None): optional path to save IMF CSV data
+
+    Returns:
+        dict: IMF-derived macro parameters
+    """
+    required_indicators = {"G2_T", "G24_T", "G27_T", "G271_T"}
+    data_path = Path(data_path) if data_path is not None else None
+    response = requests.get(
+        (
+            "https://api.imf.org/external/sdmx/3.0/data/dataflow/"
+            f"IMF.STA/GFS_SOO/12.0.0/"
+            f"{country_iso}.S1311.G2M.*.POGDP_PT.A"
+        ),
+        timeout=30,
+    )
+    response.raise_for_status()
+    try:
+        payload = response.json()
+        data = payload["data"]
+        structure = data["structures"][0]
+        data_set = data["dataSets"][0]
+        series_dimensions = structure["dimensions"]["series"]
+        observation_years = [
+            value.get("id", value.get("value"))
+            for value in structure["dimensions"]["observation"][0]["values"]
+        ]
+    except (ValueError, KeyError, IndexError, TypeError) as exc:
+        raise ValueError(
+            "Empty or malformed IMF response for GFS_SOO"
+        ) from exc
+
+    records = []
+    for series_key, series in data_set["series"].items():
+        dimension_indexes = [int(idx) for idx in series_key.split(":")]
+        labels = {
+            dim["id"]: dim["values"][idx]["id"]
+            for dim, idx in zip(series_dimensions, dimension_indexes)
+        }
+        indicator = labels.get("INDICATOR")
+        if indicator not in required_indicators:
+            continue
+        for observation_key, observation in series.get(
+            "observations", {}
+        ).items():
+            value = observation[0]
+            if value is None:
+                continue
+            records.append(
+                {
+                    "year": observation_years[int(observation_key)],
+                    "indicator": indicator,
+                    "value": float(value),
+                    "country_iso": country_iso,
+                    "sector": "S1311",
+                    "dataset": "IMF.STA:GFS_SOO(12.0.0)",
+                }
+            )
+
+    imf_data = pd.DataFrame(records)
+    if imf_data.empty:
+        raise ValueError("Empty or malformed IMF response for GFS_SOO")
+
+    if data_path is not None:
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        imf_data.sort_values(["indicator", "year"]).to_csv(
+            data_path, index=False
+        )
+        print(f"IMF data saved to {data_path}")
+
+    imf_data["year"] = pd.to_numeric(imf_data["year"], errors="coerce")
+    imf_data["value"] = pd.to_numeric(imf_data["value"], errors="coerce")
+    imf_data = imf_data.dropna(subset=["year", "value"])
+
+    available = (
+        imf_data.pivot_table(
+            index="year",
+            columns="indicator",
+            values="value",
+            aggfunc="first",
+        )
+        .sort_index()
+        .dropna(subset=sorted(required_indicators))
+    )
+    available = available.loc[available.index <= int(target_year)]
+
+    if available.empty:
+        raise ValueError(
+            f"No complete IMF data available for {country_iso} up to {target_year}"
+        )
+
+    selected_year = (
+        int(target_year)
+        if int(target_year) in available.index
+        else int(available.index.max())
+    )
+    if selected_year != int(target_year):
+        print(
+            f"Warning: No IMF data for {target_year}. "
+            f"Using last available year: {selected_year}"
+        )
+
+    values = available.loc[selected_year]
+    return {
+        "alpha_T": [(values["G27_T"] - values["G271_T"]) / 100],
+        "alpha_G": [
+            (values["G2_T"] - values["G24_T"] - values["G27_T"]) / 100
+        ],
+    }
+
+
+def _get_ilo_gamma(country_iso, start_year, target_year):
+    """
+    Fetch ILO labor-share data and compute capital's share of income.
+    """
+    target = (
+        "https://rplumber.ilo.org/data/indicator/"
+        + "?id=LAP_2GDP_NOC_RT_A"
+        + "&ref_area="
+        + str(country_iso)
+        + "&timefrom="
+        + str(start_year)
+        + "&type=both&format=.csv"
+    )
+    print("ILO data target = ", target)
+    response = requests.get(target, headers=ILOSTAT_HEADERS, timeout=30)
+    response.raise_for_status()
+    ilo_data = pd.read_csv(StringIO(response.text))[["time", "obs_value"]]
+    ilo_data["time"] = pd.to_numeric(ilo_data["time"], errors="coerce")
+    ilo_data["obs_value"] = pd.to_numeric(
+        ilo_data["obs_value"], errors="coerce"
+    )
+    ilo_data = ilo_data.dropna(subset=["time", "obs_value"])
+    labor_share = _latest_at_or_before(
+        ilo_data.set_index("time")["obs_value"],
+        target_year,
+        "ILOSTAT",
+    )
+    return [1 - (labor_share / 100)]
 
 
 def get_macro_params(
     data_start_date=datetime.datetime(1947, 1, 1),
     data_end_date=datetime.datetime(2023, 1, 1),
     country_iso="PHL",
+    update_from_api=False,
+    imf_data_path=None,
 ):
     """
-    Compute values of parameters that are derived from macro data
+    Compute values of parameters that are derived from macro data.
 
     Args:
         data_start_date (datetime): start date for data
         data_end_date (datetime): end date for data
         country_iso (str): ISO code for country
+        update_from_api (bool): Set True to pull updated macro data
+        imf_data_path (str | Path | None): optional path to save IMF CSV data
 
     Returns:
         macro_parameters (dict): dictionary of parameter values
     """
-    # initialize a dictionary of parameters
     macro_parameters = {}
 
-    """
-    Retrieve data from the World Bank World Development Indicators.
-    """
-    # Dictionaries of variables and their corresponding World Bank codes
-    # Annual data
     wb_a_variable_dict = {
         "GDP per capita (constant 2015 US$)": "NY.GDP.PCAP.KD",
         "Real GDP (constant 2015 US$)": "NY.GDP.MKTP.KD",
@@ -46,33 +313,23 @@ def get_macro_params(
         "External debt stocks, public and publicly guaranteed (PPG) (DOD, current US$)": "DT.DOD.DPPG.CD",
         "External debt stocks, total (DOD, current US$)": "DT.DOD.DECT.CD",
         r"External debt stocks (% of GNI)": "DT.DOD.DECT.GN.ZS",
-        r"Central government debt, total (% of GDP)": "GC.DOD.TOTL.GD.ZS",
-        r"General government final consumption expenditure (% of GDP)": "NE.CON.GOVT.ZS",
     }
-    try:
-        # pull series of interest from the WB using pandas_datareader
-        # Annual data
-        wb_data_a = wb.WorldBankReader(
-            symbols=wb_a_variable_dict.values(),
-            countries=country_iso,
-            start=data_start_date,
-            end=data_end_date,
-            freq="A",
-        ).read()
-        wb_data_a.rename(
-            columns=dict((y, x) for x, y in wb_a_variable_dict.items()),
-            inplace=True,
-        )
-        # Remove the hierarchical index (country and year) of
-        # wb_data_a and create a single row index using year
-        wb_data_a.reset_index(inplace=True)
-        wb_data_a["year"] = wb_data_a.year.astype(int)
-        wb_data_a = wb_data_a.set_index("year")
-        # Compute macro parameters from WB data
-        # Latest from WB WDI data is 2014, so use: https://www.treasury.gov.ph/?p=64737
-        macro_parameters["initial_debt_ratio"] = 0.60
-        macro_parameters["initial_foreign_debt_ratio"] = (
-            pd.Series(
+
+    if update_from_api:
+        try:
+            wb_data_a = _annual_index(
+                _fetch_wb_data(
+                    wb_a_variable_dict,
+                    country_iso,
+                    data_start_date.year,
+                    data_end_date.year,
+                    source=2,
+                )
+            )
+            # Gross national government debt as a share of GDP. This is a
+            # documented baseline source value, not computed from the WDI pull.
+            macro_parameters["initial_debt_ratio"] = 0.60
+            foreign_debt_ratio = (
                 wb_data_a[r"External debt stocks (% of GNI)"]
                 * (
                     wb_data_a[
@@ -82,109 +339,119 @@ def get_macro_params(
                         "External debt stocks, total (DOD, current US$)"
                     ]
                 )
-            ).loc[data_end_date.year - 2]
-            / 100
-        )
-        # zeta_D = share of new debt issues from government that are
-        # purchased by foreigners
-        # set to initial ratio without better info
-        macro_parameters["zeta_D"] = [
-            macro_parameters["initial_foreign_debt_ratio"]
-        ]
-        macro_parameters["g_y_annual"] = (
-            wb_data_a["GDP per capita (constant 2015 US$)"]
-            .loc[2000:2019]  # stop pre-COVID
-            .pct_change()
-            .mean()
-        )
-        macro_parameters["alpha_G"] = [
-            (
-                wb_data_a[
-                    r"General government final consumption expenditure (% of GDP)"
-                ].loc[data_end_date.year]
                 / 100
             )
-        ]
-    except:
-        print("Failed to retrieve data from World Bank")
-        print("Will not update the following parameters:")
-        print(
-            "[initial_debt_ratio, initial_foreign_debt_ratio, zeta_D, g_y, alpha_G]"
-        )
-
-    """
-    Retrieve labour share data from the United Nations ILOSTAT Data API
-    (see https://rshiny.ilo.org/dataexplorer9/?lang=en)
-    """
-    target = (
-        "https://rplumber.ilo.org/data/indicator/"
-        + "?id=LAP_2GDP_NOC_RT_A"
-        + "&ref_area="
-        + str(country_iso)
-        + "&timefrom="
-        + str(data_start_date.year)
-        + "&timeto="
-        + str(data_end_date.year)
-        + "&type=both&format=.csv"
-    )
-    print("ILO data target = ", target)
-    response = requests.get(target, timeout=30)
-    if response.status_code == 200:
-        csv_content = StringIO(response.text)
-        df_temp = pd.read_csv(csv_content)
-    else:
-        print(
-            f"Failed to retrieve data. HTTP status code: {response.status_code}"
-        )
-    ilo_data = df_temp[["time", "obs_value"]]
-    # find gamma, capital's share of income
-    macro_parameters["gamma"] = [
-        1
-        - (
-            (
-                ilo_data.loc[
-                    ilo_data["time"] == min(data_end_date.year, 2021),
-                    "obs_value",  # 2021 is latest year of data
-                ].squeeze()
+            macro_parameters["initial_foreign_debt_ratio"] = (
+                _latest_at_or_before(
+                    foreign_debt_ratio,
+                    data_end_date.year - EXTERNAL_DEBT_REPORTING_LAG_YEARS,
+                    "World Bank external debt",
+                )
             )
-            / 100
-        )
-    ]
+            macro_parameters["zeta_D"] = [
+                macro_parameters["initial_foreign_debt_ratio"]
+            ]
+            macro_parameters["g_y_annual"] = (
+                wb_data_a["GDP per capita (constant 2015 US$)"]
+                # Use the pre-pandemic growth window to avoid COVID-era
+                # volatility driving the steady-state productivity target.
+                .loc[GDP_GROWTH_START_YEAR:GDP_GROWTH_END_YEAR]
+                .pct_change()
+                .mean()
+            )
+            print(
+                f"initial_debt_ratio set from documented source: {macro_parameters['initial_debt_ratio']}"
+            )
+            print(
+                f"initial_foreign_debt_ratio updated from World Bank API: {macro_parameters['initial_foreign_debt_ratio']}"
+            )
+            print(
+                f"zeta_D updated from World Bank API: {macro_parameters['zeta_D']}"
+            )
+            print(
+                f"g_y_annual updated from World Bank API: {macro_parameters['g_y_annual']}"
+            )
+        except Exception:
+            print("Failed to retrieve data from World Bank")
+            print("Will not update the following parameters:")
+            print(
+                "[initial_debt_ratio, initial_foreign_debt_ratio, zeta_D, g_y]"
+            )
+    else:
+        print("Not updating from World Bank API")
 
-    """
-    Calibrate parameters from IMF data
-    """
-    # alpha_T, non-social security benefits as a fraction of GDP
-    # can't find this specifically, so use primary expenditures minus
-    # final consumption expenditures
-    # source: https://www.imf.org/external/datamapper/profile/PHL
-    macro_parameters["alpha_T"] = [0.2391 - 0.142]
+    if update_from_api:
+        try:
+            macro_parameters["gamma"] = _get_ilo_gamma(
+                country_iso,
+                data_start_date.year,
+                data_end_date.year,
+            )
+            print(
+                f"gamma updated from ILOSTAT API: {macro_parameters['gamma']}"
+            )
+        except Exception:
+            print("Failed to retrieve data from ILOSTAT")
+            print("Will not update gamma")
+    else:
+        print("Not updating from ILOSTAT API")
 
-    """"
-    Esimate the discount on sovereign yields relative to private debt
-    Follow the methodology in Li, Magud, Werner, Witte (2021)
-    available at:
-    https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224
+    if update_from_api:
+        try:
+            macro_parameters.update(
+                _get_imf_macro_params(
+                    country_iso,
+                    data_end_date.year,
+                    data_path=imf_data_path,
+                )
+            )
+            print(
+                f"alpha_T updated from IMF data: {macro_parameters['alpha_T']}"
+            )
+            print(
+                f"alpha_G updated from IMF data: {macro_parameters['alpha_G']}"
+            )
+        except Exception:
+            print("Failed to retrieve data from IMF")
+            print("Will not update alpha_T, alpha_G")
 
-    Steps:
-    1) Generate modelled corporate yields (corp_yhat) for a range of
-    sovereign yields (sov_y)  using the estimated equation in col 2 of
-    table 8 (and figure 3). 2) Estimate the OLS using sovereign yields
-    as the dependent variable
-    """
+        """"
+        Esimate the discount on sovereign yields relative to private debt
+        Follow the methodology in Li, Magud, Werner, Witte (2021)
+        available at:
+        https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224
 
-    # # estimate r_gov_shift and r_gov_scale
-    sov_y = np.arange(20, 120) / 10
-    corp_yhat = 8.199 - (2.975 * sov_y) + (0.478 * sov_y**2)
-    corp_yhat = sm.add_constant(corp_yhat)
-    mod = sm.OLS(
-        sov_y,
-        corp_yhat,
-    )
-    res = mod.fit()
-    # First term is the constant and needs to be divided by 100 to have
-    # the correct unit. Second term is the coefficient
-    macro_parameters["r_gov_shift"] = [-res.params[0] / 100]
-    macro_parameters["r_gov_scale"] = [res.params[1]]
+        Steps:
+        1) Generate modelled corporate yields (corp_yhat) for a range of
+        sovereign yields (sov_y)  using the estimated equation in col 2 of
+        table 8 (and figure 3). 2) Estimate the OLS using sovereign yields
+        as the dependent variable
+        """
+        try:
+            import statsmodels.api as sm
+
+            sov_y = np.arange(20, 120) / 10
+            corp_yhat = 8.199 - (2.975 * sov_y) + (0.478 * sov_y**2)
+            corp_yhat = sm.add_constant(corp_yhat)
+            mod = sm.OLS(
+                sov_y,
+                corp_yhat,
+            )
+            res = mod.fit()
+            # First term is the constant and needs to be divided by 100 to
+            # have the correct unit. Second term is the coefficient.
+            macro_parameters["r_gov_shift"] = [-res.params[0] / 100]
+            macro_parameters["r_gov_scale"] = [res.params[1]]
+            print(
+                f"r_gov_shift updated from IMF data: {macro_parameters['r_gov_shift']}"
+            )
+            print(
+                f"r_gov_scale updated from IMF data: {macro_parameters['r_gov_scale']}"
+            )
+        except Exception:
+            print("Failed to compute r_gov_shift, r_gov_scale")
+            print("Will not update r_gov_shift, r_gov_scale")
+    else:
+        print("Not updating alpha_T, alpha_G, r_gov_shift, r_gov_scale")
 
     return macro_parameters

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
         "distributed>=2.30.1",
         "paramtools>=0.20.0",
         "requests",
-        "pandas-datareader",
         "xlwt",
         "openpyxl>=3.1.2",
         "statsmodels",

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,130 @@
+"""
+Tests of calibrate.py module offline and partial-failure behavior.
+"""
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from ogphl.calibrate import Calibration
+
+
+def _make_mock_p(I=1, M=1):
+    """Create a minimal mock Specifications object."""
+    p = MagicMock()
+    p.I = I
+    p.M = M
+    p.E = 20
+    p.S = 80
+    p.T = 160
+    p.J = 7
+    p.start_year = 2025
+    p.lambdas = np.array([0.25, 0.25, 0.0625, 0.0625, 0.0625, 0.0625, 0.25])
+    return p
+
+
+class TestOfflineMode:
+    """Tests for update_from_api=False."""
+
+    def test_single_sector_returns_identity_values(self):
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        np.testing.assert_array_equal(d["alpha_c"], np.array([1.0]))
+        np.testing.assert_array_equal(d["io_matrix"], np.array([[1.0]]))
+
+    def test_single_sector_no_demographics_or_macro(self):
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    def test_multi_sector_omits_alpha_c_and_io_matrix(self):
+        p = _make_mock_p(I=5, M=4)
+        c = Calibration(p, update_from_api=False)
+
+        assert c.get_dict() == {}
+        assert c.alpha_c is None
+        assert c.io_matrix is None
+
+    @patch("ogphl.calibrate.macro_params")
+    @patch("ogphl.calibrate.io")
+    def test_no_external_calls(self, mock_io, mock_macro):
+        p = _make_mock_p(I=5, M=4)
+        Calibration(p, update_from_api=False)
+
+        mock_macro.get_macro_params.assert_not_called()
+        mock_io.get_alpha_c.assert_not_called()
+        mock_io.get_io_matrix.assert_not_called()
+
+
+class TestOnlinePartialFailure:
+    """Tests for update_from_api=True with mocked partial failures."""
+
+    @patch("ogphl.calibrate.macro_params")
+    def test_macro_failure_warns_and_omits(self, mock_macro):
+        mock_macro.get_macro_params.side_effect = RuntimeError("API down")
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        macro_warnings = [x for x in w if "Macro params" in str(x.message)]
+        assert len(macro_warnings) == 1
+
+        d = c.get_dict()
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    @patch("ogphl.calibrate.io")
+    @patch("ogphl.calibrate.macro_params")
+    def test_sam_failure_warns_and_omits(self, mock_macro, mock_io):
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+        mock_io.get_alpha_c.side_effect = RuntimeError("SAM unavailable")
+        mock_io.get_io_matrix.side_effect = RuntimeError("SAM unavailable")
+
+        p = _make_mock_p(I=5, M=4)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        assert len([x for x in w if "alpha_c" in str(x.message)]) == 1
+        assert len([x for x in w if "io_matrix" in str(x.message)]) == 1
+
+        d = c.get_dict()
+        assert "alpha_c" not in d
+        assert "io_matrix" not in d
+        assert d["g_y_annual"] == 0.01
+
+    @patch("ogphl.calibrate.macro_params")
+    def test_demographics_failure_warns_and_omits(self, mock_macro):
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("UN API down")
+                c = Calibration(p, update_from_api=True)
+
+        assert len([x for x in w if "Demographics" in str(x.message)]) == 1
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        assert d["g_y_annual"] == 0.01
+        assert "alpha_c" in d
+        assert "io_matrix" in d

--- a/tests/test_income.py
+++ b/tests/test_income.py
@@ -6,7 +6,6 @@ import pytest
 import numpy as np
 from ogphl import income
 
-
 # @pytest.mark.parametrize(
 #     "abil_wgts,expected_vals",
 #     [

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -7,7 +7,6 @@ import pytest
 from unittest.mock import patch
 from ogphl import input_output as io
 
-
 sam_dict = {
     # "index": ["Beer", "Chocolate", "Car", "House"],
     "Ag": [30, 160, 0, 5],

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -4,6 +4,7 @@ Tests of input_output.py module
 
 import pandas as pd
 import pytest
+from unittest.mock import patch
 from ogphl import input_output as io
 
 
@@ -73,3 +74,21 @@ def test_get_io_matrix(sam_df, cons_dict, prod_dict):
     assert list(test_df.index).sort() == ["Food", "Non-food"].sort()
     assert test_df.loc["Food", "Primary"] == 2 / 3
     assert test_df.loc["Food", "Secondary"] == 1 / 3
+
+
+@patch("ogphl.input_output.read_SAM", return_value=None)
+def test_get_alpha_c_raises_on_none_sam(mock_read_sam):
+    """
+    get_alpha_c() raises RuntimeError when SAM data is unavailable.
+    """
+    with pytest.raises(RuntimeError, match="Cannot compute alpha_c"):
+        io.get_alpha_c()
+
+
+@patch("ogphl.input_output.read_SAM", return_value=None)
+def test_get_io_matrix_raises_on_none_sam(mock_read_sam):
+    """
+    get_io_matrix() raises RuntimeError when SAM data is unavailable.
+    """
+    with pytest.raises(RuntimeError, match="Cannot compute io_matrix"):
+        io.get_io_matrix()

--- a/tests/test_macro_params.py
+++ b/tests/test_macro_params.py
@@ -1,17 +1,257 @@
 """
-Tests of macro_params.py module
+Tests of macro_params.py module.
 """
+
+import datetime
+import sys
+import types
+
+import pytest
+import requests
 
 from ogphl import macro_params
 
 
-def test_get_macro_params():
-    test_dict = macro_params.get_macro_params()
+class MockResponse:
+    """Minimal mock response for requests.get()."""
+
+    def __init__(self, *, json_data=None, text="", status_code=200):
+        self._json_data = json_data
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"HTTP {self.status_code} returned from mocked request"
+            )
+
+
+def _wb_payload(observations):
+    return [
+        {
+            "page": 1,
+            "pages": 1,
+            "per_page": "10000",
+            "total": len(observations),
+        },
+        [
+            {
+                "date": date,
+                "value": value,
+                "indicator": {"id": "mock-indicator"},
+            }
+            for date, value in observations
+        ],
+    ]
+
+
+def _imf_payload(indicator_year_values):
+    years = sorted(
+        {
+            int(year)
+            for observations in indicator_year_values.values()
+            for year in observations.keys()
+        }
+    )
+    indicators = list(indicator_year_values.keys())
+    return {
+        "meta": {},
+        "data": {
+            "dataSets": [
+                {
+                    "structure": 0,
+                    "action": "Replace",
+                    "series": {
+                        f"0:0:0:{indicator_idx}:0:0": {
+                            "attributes": [0, None, None],
+                            "observations": {
+                                str(years.index(int(year))): [str(value)]
+                                for year, value in observations.items()
+                            },
+                        }
+                        for indicator_idx, observations in enumerate(
+                            indicator_year_values.values()
+                        )
+                    },
+                }
+            ],
+            "structures": [
+                {
+                    "dimensions": {
+                        "series": [
+                            {"id": "COUNTRY", "values": [{"id": "PHL"}]},
+                            {"id": "SECTOR", "values": [{"id": "S1311"}]},
+                            {"id": "GFS_GRP", "values": [{"id": "G2M"}]},
+                            {
+                                "id": "INDICATOR",
+                                "values": [
+                                    {"id": indicator}
+                                    for indicator in indicators
+                                ],
+                            },
+                            {
+                                "id": "TYPE_OF_TRANSFORMATION",
+                                "values": [{"id": "POGDP_PT"}],
+                            },
+                            {"id": "FREQUENCY", "values": [{"id": "A"}]},
+                        ],
+                        "observation": [
+                            {
+                                "id": "TIME_PERIOD",
+                                "values": [
+                                    {"value": str(year)} for year in years
+                                ],
+                            }
+                        ],
+                    },
+                    "measures": {
+                        "observation": [{"id": "OBS_VALUE", "roles": []}]
+                    },
+                    "attributes": {
+                        "dimensionGroup": [],
+                        "series": [],
+                        "observation": [],
+                    },
+                    "annotations": [],
+                }
+            ],
+        },
+    }
+
+
+def _mock_requests_get(monkeypatch, wb_payloads, ilo_text=None, imf_json=None):
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if "worldbank.org" in url:
+            indicator_code = url.rstrip("/").split("/")[-1]
+            return MockResponse(json_data=wb_payloads[indicator_code])
+        if "rplumber.ilo.org" in url:
+            assert "timeto=" not in url
+            assert headers == macro_params.ILOSTAT_HEADERS
+            return MockResponse(
+                text=ilo_text or "time,obs_value\n2026,45\n2024,44\n2023,40\n"
+            )
+        if "api.imf.org" in url:
+            return MockResponse(
+                json_data=imf_json
+                or _imf_payload(
+                    {
+                        "G2_T": {2023: 16.0, 2024: 17.0},
+                        "G24_T": {2023: 2.0, 2024: 2.5},
+                        "G27_T": {2023: 1.0, 2024: 1.25},
+                        "G271_T": {2023: 0.25, 2024: 0.25},
+                    }
+                )
+            )
+        raise AssertionError(f"Unexpected URL requested in test: {url}")
+
+    monkeypatch.setattr(macro_params.requests, "get", fake_get)
+
+
+def _mock_statsmodels(monkeypatch, params=None):
+    fake_statsmodels = types.ModuleType("statsmodels")
+    fake_api = types.ModuleType("statsmodels.api")
+
+    def add_constant(values):
+        return values
+
+    class OLS:
+        def __init__(self, endog, exog):
+            self.endog = endog
+            self.exog = exog
+
+        def fit(self):
+            result = types.SimpleNamespace()
+            result.params = params or [1.0, 0.5]
+            return result
+
+    fake_api.add_constant = add_constant
+    fake_api.OLS = OLS
+    fake_statsmodels.api = fake_api
+    monkeypatch.setitem(sys.modules, "statsmodels", fake_statsmodels)
+    monkeypatch.setitem(sys.modules, "statsmodels.api", fake_api)
+
+
+def _wb_payloads():
+    return {
+        "NY.GDP.PCAP.KD": _wb_payload(
+            [("2000", 100.0), ("2001", 125.0), ("2002", 156.25)]
+        ),
+        "NY.GDP.MKTP.KD": _wb_payload([("2021", 1000.0)]),
+        "NY.GDP.MKTP.CD": _wb_payload([("2021", 1100.0)]),
+        "NE.CON.GOVT.CD": _wb_payload([("2021", 100.0)]),
+        "DT.DOD.DPPG.CD": _wb_payload([("2021", 40.0)]),
+        "DT.DOD.DECT.CD": _wb_payload([("2021", 100.0)]),
+        "DT.DOD.DECT.GN.ZS": _wb_payload([("2021", 50.0)]),
+    }
+
+
+def test_fetch_wb_data_annual_success(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        {
+            "NY.GDP.PCAP.KD": _wb_payload(
+                [("2022", 64.0), ("2024", 100.0), ("2023", 80.0)]
+            )
+        },
+    )
+
+    data = macro_params._fetch_wb_data(
+        {"GDP per capita (constant 2015 US$)": "NY.GDP.PCAP.KD"},
+        "PHL",
+        2022,
+        2024,
+        source=2,
+    )
+
+    assert list(data.index) == ["2024", "2023", "2022"]
+    assert list(data.columns) == ["GDP per capita (constant 2015 US$)"]
+    assert data.loc["2024", "GDP per capita (constant 2015 US$)"] == 100.0
+
+
+def test_fetch_wb_data_empty_payload_raises_value_error(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        {"NY.GDP.PCAP.KD": [{"page": 1, "pages": 1, "total": 0}, []]},
+    )
+
+    with pytest.raises(ValueError, match="Empty or malformed World Bank"):
+        macro_params._fetch_wb_data(
+            {"GDP per capita (constant 2015 US$)": "NY.GDP.PCAP.KD"},
+            "PHL",
+            2022,
+            2024,
+            source=2,
+        )
+
+
+def test_get_macro_params_update_from_api_false_returns_empty_dict():
+    test_dict = macro_params.get_macro_params(update_from_api=False)
 
     assert isinstance(test_dict, dict)
-    assert (
-        list(test_dict.keys()).sort()
-        == [
+    assert test_dict == {}
+
+
+def test_get_macro_params_update_from_api_true(monkeypatch):
+    _mock_statsmodels(monkeypatch)
+    _mock_requests_get(
+        monkeypatch,
+        _wb_payloads(),
+        ilo_text="time,obs_value\n2026,45\n2024,44\n2023,40\n",
+    )
+
+    test_dict = macro_params.get_macro_params(
+        data_end_date=datetime.datetime(2023, 1, 1),
+        update_from_api=True,
+    )
+
+    assert sorted(test_dict.keys()) == sorted(
+        [
             "r_gov_shift",
             "r_gov_scale",
             "alpha_T",
@@ -21,5 +261,93 @@ def test_get_macro_params():
             "gamma",
             "zeta_D",
             "initial_foreign_debt_ratio",
-        ].sort()
+        ]
     )
+    assert test_dict["initial_debt_ratio"] == 0.6
+    assert test_dict["initial_foreign_debt_ratio"] == pytest.approx(0.2)
+    assert test_dict["zeta_D"] == [pytest.approx(0.2)]
+    assert test_dict["g_y_annual"] == pytest.approx(0.25)
+    assert test_dict["gamma"] == [pytest.approx(0.6)]
+    assert test_dict["alpha_T"] == [pytest.approx(0.0075)]
+    assert test_dict["alpha_G"] == [pytest.approx(0.13)]
+    assert test_dict["r_gov_shift"] == [-0.01]
+    assert test_dict["r_gov_scale"] == [0.5]
+
+
+def test_get_ilo_gamma_uses_latest_year_at_or_before_target(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        {},
+        ilo_text="time,obs_value\n2026,45\n2024,44\n2023,40\n",
+    )
+
+    gamma = macro_params._get_ilo_gamma("PHL", 1947, 2024)
+
+    assert gamma == [pytest.approx(0.56)]
+
+
+def test_get_imf_macro_params_overwrites_saved_file(monkeypatch, tmp_path):
+    _mock_requests_get(
+        monkeypatch,
+        {},
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 16.0, 2024: 17.0},
+                "G24_T": {2023: 2.0, 2024: 2.5},
+                "G27_T": {2023: 1.0, 2024: 1.25},
+                "G271_T": {2023: 0.25, 2024: 0.25},
+            }
+        ),
+    )
+
+    data_file = tmp_path / "imf_gfs_soo_phl_s1311_g2m_pogdp_pt_a.csv"
+    result = macro_params._get_imf_macro_params(
+        "PHL", 2024, data_path=data_file
+    )
+
+    assert result["alpha_T"] == [pytest.approx(0.01)]
+    assert result["alpha_G"] == [pytest.approx(0.1325)]
+    assert data_file.exists()
+
+    _mock_requests_get(
+        monkeypatch,
+        {},
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2024: 18.0},
+                "G24_T": {2024: 2.75},
+                "G27_T": {2024: 1.5},
+                "G271_T": {2024: 0.5},
+            }
+        ),
+    )
+
+    refreshed = macro_params._get_imf_macro_params(
+        "PHL", 2024, data_path=data_file
+    )
+
+    assert refreshed != result
+    saved_data = macro_params.pd.read_csv(data_file)
+    saved_2024 = saved_data[saved_data["year"] == 2024].set_index("indicator")
+    assert saved_2024.loc["G27_T", "value"] == pytest.approx(1.5)
+    assert saved_2024.loc["G271_T", "value"] == pytest.approx(0.5)
+
+
+def test_get_imf_macro_params_falls_back_to_last_available_year(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        {},
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 16.0},
+                "G24_T": {2023: 2.0},
+                "G27_T": {2023: 1.0},
+                "G271_T": {2023: 0.25},
+            }
+        ),
+    )
+
+    result = macro_params._get_imf_macro_params("PHL", 2024)
+
+    assert result["alpha_T"] == [pytest.approx(0.0075)]
+    assert result["alpha_G"] == [pytest.approx(0.13)]


### PR DESCRIPTION
This PR updates the OG-PHL calibration flow so live data refreshes are explicit, offline-safe, and resilient to individual source failures.

Changes include:

- Adds `update_from_api=False` default behavior to Calibration.
- Uses packaged/default parameters as the baseline when no online refresh is requested.
- Gates macro, SAM/input-output, demographics, and earnings refreshes behind `update_from_api=True`.
- Allows external data sources to fail independently without aborting the full calibration.
- Moves SAM loading into `read_SAM()` so missing SAM data raises catchable errors instead of failing at import.
- Updates macro refresh plumbing to use direct World Bank, ILOSTAT, and IMF SDMX API requests.
- Adds ILOSTAT request headers and selects the latest available observation at or before the target year.
- Adds IMF SDMX complete-year fallback behavior.
- Updates README/example usage for explicit online refresh.
- Updates docs workflow dependency installs for reproducible docs builds.
- Adds tests for offline mode, default behavior, partial failures, SAM failures, API request structure, and IMF fallback.