### PR TITLE
Reformat 5 .py files for black 26.3.1

### DIFF
--- a/docs/book/content/UNtutorial/solutions/3perOG/SS.py
+++ b/docs/book/content/UNtutorial/solutions/3perOG/SS.py
@@ -28,7 +28,6 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
 import os
 
-
 # Define functions
 
 

--- a/docs/create_doc_figures.py
+++ b/docs/create_doc_figures.py
@@ -14,7 +14,6 @@ from ogcore import parameter_plots as pp
 from ogcore import demographics as demog
 import ogphl
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 UN_COUNTRY_CODE = "608"
 plot_path = os.path.join(CUR_DIR, "book", "content", "calibration", "images")

--- a/ogphl/input_output.py
+++ b/ogphl/input_output.py
@@ -3,7 +3,6 @@ import numpy as np
 import os
 from ogphl.constants import CONS_DICT, PROD_DICT
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 """
 Read in Social Accounting Matrix (SAM) file

--- a/tests/test_income.py
+++ b/tests/test_income.py
@@ -6,7 +6,6 @@ import pytest
 import numpy as np
 from ogphl import income
 
-
 # @pytest.mark.parametrize(
 #     "abil_wgts,expected_vals",
 #     [

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from ogphl import input_output as io
 
-
 sam_dict = {
     # "index": ["Beer", "Chocolate", "Car", "House"],
     "Ag": [30, 160, 0, 5],


### PR DESCRIPTION
Reformats 5 .py files that have drifted from current black formatting. Pure whitespace — one redundant blank line removed between imports and the next code section in each file. No logic changes.

Unblocks the lint check for #50 (and PR #48 once approved). Root cause tracked in #51.