### PR TITLE
Update calibration docs to match PR #48 parameter values and sources

### DIFF
--- a/docs/book/content/calibration/exogenous_parameters.md
+++ b/docs/book/content/calibration/exogenous_parameters.md
@@ -37,7 +37,7 @@ kernelspec:
 
 | Symbol                           | Description                                                             | Value                                                 |
 |:---------------------------------|:------------------------------------------------------------------------|:------------------------------------------------------|
-| $\texttt{start_year}$            | Initial year                                                            | 2023                                                  |
+| $\texttt{start_year}$            | Initial year                                                            | 2026                                                  |
 | $\omega_{s,t}$                   | Population by age over time                                             | Too large to report here, see default parameters JSON |
 | $i_{s,t}$                        | Immigration rates by age                                                | Too large to report here, see default parameters JSON |
 | $\rho_{s,t}$                    | Mortality rates by age                                                  | Too large to report here, see default parameters JSON |
@@ -67,7 +67,7 @@ kernelspec:
 | $\texttt{analytical_mtrs}$      | Whether use analytical MTRs or estimate MTRs                            | 0.00E+00                                              |
 | $\texttt{age_specific}$         | Whether use age-specific tax functions                                  | 1.000                                                 |
 | $\tau^{p}_{t}$                   | Payroll tax rate                                                        | [0.140...0.140]                                       |
-| $\tau^{BQ}_{t}$                  | Bequest (estate) tax rate                                               | [0.200...0.200]                                       |
+| $\tau^{BQ}_{t}$                  | Bequest (estate) tax rate                                               | [0.060...0.060]                                       |
 | $\tau^{b}_{t}$                   | Entity-level business income tax rate                                   | Too large to report here, see default parameters JSON |
 | $\delta^{\tau}_{t}$              | Rate of depreciation for tax purposes                                   | Too large to report here, see default parameters JSON |
 | $\tau^{c}_{t,s,j}$               | Consumption tax rates                                                   | Too large to report here, see default parameters JSON |
@@ -76,10 +76,10 @@ kernelspec:
 | $P$                              | Coefficient on level term in wealth tax function                        | [0.000...0.000]                                       |
 | $\texttt{budget_balance}$       | Whether have a balanced budget in each period                           | 0.00E+00                                              |
 | $\texttt{baseline_spending}$    | Whether level of spending constant between the baseline and reform runs | 0.00E+00                                              |
-| $\alpha^{T}_{t}$                 | Transfers as a share of GDP                                             | [0.097...0.097]                                       |
+| $\alpha^{T}_{t}$                 | Transfers as a share of GDP                                             | [0.0448...0.0448]                                     |
 | $\eta_{j,s,t}$                   | Distribution of transfers                                               | Too large to report here, see default parameters JSON |
-| $\alpha^{G}_{t}$                 | Government spending as a share of GDP                                   | [0.215, 0.209, 0.207]                                  |
-| $\alpha^{I}_{t}$                 | Government infrastructure spending as a share of GDP                    | [0.054, 0.054, 0.056]                                 |
+| $\alpha^{G}_{t}$                 | Government spending as a share of GDP                                   | [0.1702, 0.1632, 0.1612]                              |
+| $\alpha^{I}_{t}$                 | Government infrastructure spending as a share of GDP                    | [0.051, 0.051, 0.052]                                 |
 | $t_{G1}$                         | Model period in which budget closure rule starts                        | 20                                                    |
 | $t_{G2}$                         | Model period in which budget closure rule ends                          | 256                                                   |
 | $\rho_{G}$                       | Budget closure rule smoothing parameter                                 | 0.100                                                 |
@@ -97,8 +97,8 @@ kernelspec:
 | $\texttt{PIA_minpayment}$       | Minimum PIA payment                                                     | 0.00E+00                                              |
 | $\theta_{adj,t}$                 | Adjustment to replacement rate                                          | [1.000...1.000]                                       |
 | $r^{*}_{t}$                      | World interest rate                                                     | [0.040...0.040]                                       |
-| $D_{f,0}$                        | Share of government debt held by foreigners in initial period           | 0.146                                                 |
-| $\zeta_{D, t}$                   | Share of new debt issues purchased by foreigners                        | [0.146...0.146]                                       |
+| $D_{f,0}$                        | Share of government debt held by foreigners in initial period           | 0.200                                                 |
+| $\zeta_{D, t}$                   | Share of new debt issues purchased by foreigners                        | [0.200...0.200]                                       |
 | $\zeta_{K, t}$                   | Share of excess capital demand satisfied by foreigners                  | [0.900...0.900]                                       |
 | $\xi$                            | Dampening parameter for TPI                                             | 0.400                                                 |
 | $\texttt{maxiter}$               | Maximum number of iterations for TPI                                    | 250                                                   |

--- a/docs/book/content/calibration/government.md
+++ b/docs/book/content/calibration/government.md
@@ -3,13 +3,13 @@
 
 ## Government Transfers as a Share of GDP
 
-We have calibrated Philippine government spending on transfer programs as a percent of GDP as $\alpha_T=[0.0971]$. [TODO: Include citation.]
+We calibrate Philippine government spending on transfer programs as a percent of GDP as $\alpha_T=[0.0448]$, using World Bank World Development Indicators data for 2023.
 
 ## Government Spending as a Share of GDP
 
-The 2025 Budget of Expenditures and Sources of Financing Table A2 https://www.dbm.gov.ph/index.php/2025/budget-of-expenditures-and-sources-of-financing-fy-2025 forecasts total federal spending as a percent of GDP in 2025, 2026, and 2027 as 21.5%, 20.9%, and 20.7%, respectively. To get the portion that is net of transfers, we subtract off the calibrated percentage of spending on transfers as a percent of GDP $\alpha_T=[0.0971]$. This gives our calibration for government spending net of transfers as a percent of GDP for 2025, 2026, and 2027 as $\alpha_G=[0.1179, 0.1119, 0.1099]$.
+The Department of Budget and Management (DBM), Budget of Expenditures and Sources of Financing (BESF) for FY 2026, Table A2 ([source](https://www.dbm.gov.ph/wp-content/uploads/BESF/BESF2026/A2.pdf)) forecasts total federal disbursements as a percent of GDP in 2026, 2027, and 2028 as 21.5%, 20.8%, and 20.6%, respectively. To get the portion that is net of transfers, we subtract off the calibrated share of spending on transfers $\alpha_T=[0.0448]$ from each. This gives our calibration for government spending net of transfers as a percent of GDP for 2026, 2027, and 2028 as $\alpha_G=[0.1702, 0.1632, 0.1612]$.
 
 
 ### Government spending on infrastructure as a share of GDP
 
-We've calibrated the vector $\alpha_I=[0.054, 0.054, 0.056]$. These values are forecasts for 2025, 2026 and 2027. This came from the 2025 Budget of Expenditures and Sources of Financing Table A2 https://www.dbm.gov.ph/index.php/2025/budget-of-expenditures-and-sources-of-financing-fy-2025
+We calibrate the vector $\alpha_I=[0.051, 0.051, 0.052]$. These values are forecasts for 2026, 2027, and 2028, taken directly from the "Infrastructure Program (Disbursements), Percent of GDP" row of the DBM, BESF for FY 2026, Table A2 ([source](https://www.dbm.gov.ph/wp-content/uploads/BESF/BESF2026/A2.pdf)).

--- a/docs/book/content/calibration/macro.md
+++ b/docs/book/content/calibration/macro.md
@@ -3,21 +3,25 @@
 
 ## Economic Assumptions
 
-As the default rate of labor augmenting technological change, $g_y$, we use a value of 3.6%.  The average annual growth rate in GDP per capita in the Philippines between 2000 and 2019 is 3.6% per year.
+As the default rate of labor augmenting technological change, $g_y$, we use a value of 3.6%. The average annual growth rate in GDP per capita in the Philippines between 2000 and 2019 is 3.6% per year. The pre-pandemic window is used deliberately to avoid COVID-era volatility distorting the steady-state productivity target.
 
 ## Open Economy Parameters
 
 ### Foreign holding of government debt in the initial period
 
-The path of foreign holding of domestic debt is endogenous, but the initial period stock of debt held by foreign investors is exogenous.  We set this parameter, `initial_foreign_debt_ratio` to 0.142, as determined from data from the World Bank's World Development Indicators.
+The path of foreign holding of domestic debt is endogenous, but the initial period stock of debt held by foreign investors is exogenous. We set this parameter, `initial_foreign_debt_ratio`, to 0.2, based on the Bureau of the Treasury (BTr) Debt Indicator report for Q4 2025 ([source](https://www.treasury.gov.ph/wp-content/uploads/2026/02/Debt-Indicator-December-2025.pdf)).
 
 ### Foreign purchases of newly issued debt
 
-We set $\zeta_D = 0.142$.  This was not directly observed in the data, so the value was set to the current share of foreign holdings of government debt.
+We set $\zeta_D = 0.2$. This is calibrated to equal `initial_foreign_debt_ratio` above, on the assumption that the foreign share of newly issued debt matches the foreign share of the existing stock.
 
 ### Foreign holdings of excess capital
 
-We set $\zeta_K = 0.9$. Note, this parameter is harder to pin down from the data as foreign purchases on "excess" capital demand is not typically directly measured or reported.  A value of 0.9 implies a high degree of openness to international capital flows.
+We set $\zeta_K = 0.9$. Note, this parameter is harder to pin down from the data as foreign purchases on "excess" capital demand is not typically directly measured or reported. A value of 0.9 implies a high degree of openness to international capital flows.
+
+### Remittances as a share of GDP
+
+Personal remittance inflows to the Philippines are a substantial component of household income. The ratio of aggregate remittances to GDP is governed by two parameters: $\alpha_{RM,1}$ for the model's start period and $\alpha_{RM,T}$ for the long run / steady state. Both are set to 0.072 (7.2%), based on Bangko Sentral ng Pilipinas (BSP) data for 2025 ([source](https://www.bsp.gov.ph/SitePages/MediaAndResearch/MediaDisp.aspx?ItemId=7821&MType=MediaReleases)). The long-run value is calibrated to equal the current-period value.
 
 ## Government Debt, Spending and Transfers
 
@@ -27,10 +31,18 @@ The path of government debt is endogenous.  But the initial value is exogenous. 
 
 ### Aggregate transfers
 
-Aggregate (non-Social Security) transfers to households are set as a share of GDP with the parameter $\alpha_T$. We exclude Social Security from transfers since it is modeled specifically. With this definition, the share of transfers to GDP in 2023 is found to be 9.7% using [IMF data](https://www.imf.org/external/datamapper/profile/PHL).  The value found by differencing out government consumption expenditures (described below) from total government spending as report in the IMF data.
+Aggregate (non-Social Security) transfers to households are set as a share of GDP with the parameter $\alpha_T$. We exclude Social Security from transfers since it is modeled specifically. We set $\alpha_T = [0.0448]$ (4.48%) using World Bank World Development Indicators data for 2023. The value is computed as the product of total government expense as a share of GDP (WDI series `GC.XPN.TOTL.GD.ZS`) and the share of that expense classified as subsidies and other transfers.
 
 ### Government expenditures
 
-Government spending on goods and services are also set as a share of GDP with the parameter $\alpha_G$. We define government spending as:
+Government spending on goods and services is set as a share of GDP with the parameter $\alpha_G$. We define government spending as:
     <center>Government Spending = Total Outlays - Transfers - Net Interest on Debt - Social Security</center>
-With this definition, the share of government expenditure to GDP is 14.2% based on the World Bank World Development Indicators.
+We set $\alpha_G = [0.1702, 0.1632, 0.1612]$ for years 2026, 2027, and 2028, derived from the Department of Budget and Management (DBM), Budget of Expenditures and Sources of Financing (BESF) for FY 2026, Table A2 ([source](https://www.dbm.gov.ph/wp-content/uploads/BESF/BESF2026/A2.pdf)). Specifically, total disbursements as a percent of GDP are 21.5%, 20.8%, and 20.6% for those years; subtracting $\alpha_T = 0.0448$ from each gives the values above.
+
+### Government interest rate wedge
+
+The interest rate the government pays on its debt, $r_{gov,t}$, generally differs from the household interest rate $r_t$ — sovereigns often borrow at lower rates than the private market because they are seen as safer borrowers. OG-Core models this gap as:
+
+$$r_{gov,t} = \max(r_{gov,scale} \cdot r_t - r_{gov,shift},\; 0)$$
+
+For the Philippines, the two parameters are $r_{gov,scale} = 0.245$ and $r_{gov,shift} = -0.034$. They are calibrated from Philippine sovereign-vs-corporate yield data sourced from the IMF, following the methodology in Li, Magud, Werner, and Witte (2021), [The Long-Run Impact of Sovereign Yields on Corporate Yields in Emerging Markets](https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224) (IMF Working Paper No. WP/21/155).

--- a/docs/book/content/calibration/taxes.md
+++ b/docs/book/content/calibration/taxes.md
@@ -14,7 +14,11 @@ The government sector influences households through two terms in the household b
   &\quad\forall j,t\quad\text{and}\quad s\geq E+1 \quad\text{where}\quad b_{j,E+1,t}=0\quad\forall j,t
 ```
 
-The total tax function, $T_{s,t}$, is a function of personal income taxes, taxes on bequests, and wealth taxes.  In the default calibration, wealth and bequest taxes are set to zero in `OG-PHL`. Personal income taxes are modeled as linear taxes and set to average effective and marginal tax rates. The [OG-Core documentation](https://pslmodels.github.io/OG-Core/content/theory/government.html#taxes) details more detailed ways to match the progressivity of the tax system.  But given limited data for Philippines, we start with simple linear tax rates of 12% for effective tax rates on personal income, a 18% marginal tax rate on capital income, and a 18\% marginal tax rate on labor income.
+The total tax function, $T_{s,t}$, is a function of personal income taxes, taxes on bequests, and wealth taxes. In the default calibration, wealth taxes are set to zero in `OG-PHL`. The bequest tax $\tau_{bq}$ is set to 6%, matching the statutory estate tax rate established by the TRAIN Law (Republic Act No. 10963), as published by the Bureau of Internal Revenue ([source](https://www.bir.gov.ph/estate-tax)).
+
+Personal income taxes are modeled as linear taxes and set to average effective and marginal tax rates. The [OG-Core documentation](https://pslmodels.github.io/OG-Core/content/theory/government.html#taxes) details more sophisticated ways to match the progressivity of the tax system. But given limited data for the Philippines, we start with simple linear tax rates: a 20% effective tax rate on personal income (`etr_params`, calibrated to equal the marginal tax rate on labor income), a 20% marginal tax rate on labor income (`mtrx_params`, calibrated using Department of Finance data), and a 6% marginal tax rate on capital income (`mtry_params`, set to the flat capital gains rate established by the TRAIN Law per the Bureau of Internal Revenue).
+
+The `mean_income_data` parameter, used in tax function estimation, is set to ₱353,230 — the mean family income from the Philippine Statistics Authority's Family Income and Expenditure Survey for 2023 ([source](https://psa.gov.ph/statistics/income-expenditure/fies/index)).
 
 ## Corporate income taxes
 


### PR DESCRIPTION
Updates the calibration docs to match the parameter changes in #48. Also fills in sections for a few parameters that weren't documented before.

Changes:
- `macro.md`: updated foreign debt ratio, transfers, and government spending with the new values and sources (BTr Q4 2025, World Bank WDI 2023, DBM BESF 2026). Added new sections for remittances and the government interest rate, neither of which was documented before. Small note added explaining the pre-pandemic window used for the productivity growth target.
- `government.md`: spelled out the BESF source with a link, and updated transfer, spending, and infrastructure values to match #48.
- `taxes.md`: updated the personal income tax rates. Replaced the "bequest taxes are set to zero" line with the 6% TRAIN Law estate tax. Added a one-liner on the average income figure used in tax function estimation.
- `exogenous_parameters.md`: refreshed the parameter table to reflect the new values.

Depends on #48 — the numbers here match the JSON values in that PR. This PR only updates documentation, no code or JSON changes.